### PR TITLE
fixed test for new qr_brightness default

### DIFF
--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -71,5 +71,5 @@ def test_missing_settings_get_defaults(reset_controller):
     assert controller.settings.get_value(SettingsConstants.SETTING__PARTNER_LOGOS) == SettingsConstants.OPTION__ENABLED
 
     # Hidden Settings defaults
-    assert controller.settings.get_value(SettingsConstants.SETTING__QR_BRIGHTNESS) == 189
+    assert controller.settings.get_value(SettingsConstants.SETTING__QR_BRIGHTNESS) == 62
 


### PR DESCRIPTION
Just in case it gets merged, so that test suite passes.